### PR TITLE
Fix missing emoji for color-enabled messages

### DIFF
--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -43,8 +43,9 @@ module Capistrano
 
     def attachment_payload(color, announcement)
       {
-        'channel' => slack_channel,
-        'username' => slack_username,
+        'channel'     => slack_channel,
+        'username'    => slack_username,
+        'icon_emoji'  => slack_emoji,
         'attachments' => [{
           'fallback'  => announcement,
           'text'      => announcement,


### PR DESCRIPTION
The documentation is ambiguous, but the `icon_emoji` value is used when sending message attachments, and the `attachment_payload` helper neglected to pass that along.

For #13
