### PR TITLE
using ls-remote instead of rev-parse to fetch revision

### DIFF
--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -96,7 +96,7 @@ module Capistrano
     end
 
     def revision
-      @revision ||= `git ls-remote #{repository} #{branch}`.chomp
+      @revision ||= `git ls-remote #{repository} #{branch}`.split(" ").first
     end
 
     def deploy_target

--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -91,8 +91,12 @@ module Capistrano
       fetch(:slack_destination, stage)
     end
 
+    def repository
+      fetch(:repository, 'origin')
+    end
+
     def revision
-      @revision ||= `git rev-parse #{branch}`.chomp
+      @revision ||= `git ls-remote #{repository} #{branch}`.chomp
     end
 
     def deploy_target


### PR DESCRIPTION
As per https://github.com/parkr/capistrano-slack-notify/issues/18
