### PR TITLE
Revision overwrite interfering with deploying capistrano revisions.

### DIFF
--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -95,12 +95,12 @@ module Capistrano
       fetch(:repository, 'origin')
     end
 
-    def revision
-      @revision ||= `git ls-remote #{repository} #{branch}`.split(" ").first
+    def rev
+      @rev ||= `git ls-remote #{repository} #{branch}`.split(" ").first
     end
 
     def deploy_target
-      [slack_app_name, branch].join('/') + (revision ? " (#{revision[0..5]})" : "")
+      [slack_app_name, branch].join('/') + (rev ? " (#{rev[0..5]})" : "")
     end
 
     def self.extended(configuration)


### PR DESCRIPTION
The `revision` method is overwriting the getter / setting in capistrano which stops deploying specific revisions. This PR renamed the method to `rev` to stop the collision taking place.
