### PR TITLE
added rolled back notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,17 @@ set :slack_webhook_url,   "https://hooks.slack.com/services/XXX/XXX/XXX"
 before 'deploy', 'slack:starting'
 after  'deploy', 'slack:finished'
 before 'deploy:rollback', 'slack:failed'
+after 'deploy:rollback', 'slack:rolled_back'
 ```
 
 That's it! It'll send 2 messages to `#general` as the `capistrano` user when you deploy.
 
 The tasks are:
 
-- `slack:starting` - the intent-to-deploy message
-- `slack:finished` - the completion message
-- `slack:failed`   - the failure message
+- `slack:starting`    - the intent-to-deploy message
+- `slack:finished`    - the completion message
+- `slack:failed`      - the failure message
+- `slack:rolled_back` - the rollback message
 
 **None of the tasks are automatically added**, you have to do that yourself,
 like in the usage example above.

--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -8,7 +8,8 @@ module Capistrano
       :grey  => '#CCCCCC',
       :red   => '#BB0000',
       :green => '#7CD197',
-      :blue  => '#103FFB'
+      :blue  => '#103FFB',
+      :yellow => '#FFFF00'
     }
 
     def post_to_channel(color, message)
@@ -115,6 +116,11 @@ module Capistrano
           task :starting do
             post_to_channel(:grey, "#{deployer} is deploying #{deploy_target} to #{destination}")
             set(:start_time, Time.now)
+          end
+
+          desc "Notify Slack that the rollback has completed."
+          task :rolled_back do
+            post_to_channel(:yellow, "#{deployer} has rolled back #{deploy_target}")
           end
 
           desc "Notify Slack that the deploy has completed successfully."

--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -8,8 +8,7 @@ module Capistrano
       :grey  => '#CCCCCC',
       :red   => '#BB0000',
       :green => '#7CD197',
-      :blue  => '#103FFB',
-      :yellow => '#FFFF00'
+      :blue  => '#103FFB'
     }
 
     def post_to_channel(color, message)
@@ -120,7 +119,7 @@ module Capistrano
 
           desc "Notify Slack that the rollback has completed."
           task :rolled_back do
-            post_to_channel(:yellow, "#{deployer} has rolled back #{deploy_target}")
+            post_to_channel(:green, "#{deployer} has rolled back #{deploy_target}")
           end
 
           desc "Notify Slack that the deploy has completed successfully."


### PR DESCRIPTION
added slack:rolled_back to post when a rollback occurs. Useful especially to inform when manual rollbacks occur (in addition to automatic rollbacks due to deployment failures). 

If you accept this, you may want to update the slack picture in the readme to show new message.

Thanks for the gem!
