### PR TITLE
Support getting a revision from subversion

### DIFF
--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -96,7 +96,11 @@ module Capistrano
     end
 
     def rev
-      @rev ||= `git ls-remote #{repository} #{branch}`.split(" ").first
+      if fetch(:scm) == :subversion
+        $rev ||= `svn info https://svn.suran.com/wmt/trunk/`.match(/^Revision: (\d+)$/)[1]
+      else
+        @rev ||= `git ls-remote #{repository} #{branch}`.split(" ").first
+      end
     end
 
     def deploy_target


### PR DESCRIPTION
When `:scm` is set to `:subversion` use `svn info` to get the revision instead of `git ls-remote`