### PR TITLE
feature: add changelog capability to slack notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ set :deployer,       ENV['USER'].capitalize # defaults to ENV['USER']
 set :slack_app_name, 'example-app' # defaults to :application
 set :slack_color,    false # defaults to true
 set :slack_destination, fetch(:stage, 'production') # where your code is going
+set :slack_add_changelog, true # defauts to false, add the git changelog to the slack notifiation
 ```
 
 ## Contributing


### PR DESCRIPTION
Add an option to add the git changelog in slack notification on the `slack:finished` event