### PR TITLE
Resolved conflict Ruby json with active_support json

### DIFF
--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -1,5 +1,5 @@
 require 'capistrano'
-require 'json'
+require 'active_support'
 require 'net/http'
 
 module Capistrano


### PR DESCRIPTION
```
`to_json': uninitialized constant ActiveSupport::JSON (NameError)
```
