### PR TITLE
If no branch is defined, use an empty string.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.idea/

--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -95,16 +95,28 @@ module Capistrano
       fetch(:repository, 'origin')
     end
 
+    def revision_from_branch
+      `git ls-remote #{repository} #{branch_or_not}`.split(' ').first
+    end
+
     def rev
-      @rev ||= `git ls-remote #{repository} #{branch_or_not}`.split(" ").first
+      @rev ||= fetch(:revision, revision_from_branch)
     end
 
     def branch_or_not
       fetch(:branch, '')
     end
 
+    def slack_app_and_branch
+      if branch_or_not.nil?
+        slack_app_name
+      else
+        [slack_app_name, branch_or_not].join('/')
+      end
+    end
+
     def deploy_target
-      [slack_app_name, branch_or_not].join('/') + (rev ? " (#{rev[0..5]})" : "")
+      slack_app_and_branch + (rev ? " (#{rev[0..5]})" : '')
     end
 
     def self.extended(configuration)

--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -96,22 +96,26 @@ module Capistrano
     end
 
     def revision_from_branch
-      `git ls-remote #{repository} #{branch_or_not}`.split(' ').first
+      `git ls-remote #{repository} #{branch}`.split(' ').first
     end
 
     def rev
-      @rev ||= fetch(:revision, revision_from_branch)
+      @rev ||= if @branch.nil?
+                 fetch(:revision)
+               else
+                 revision_from_branch
+               end
     end
 
-    def branch_or_not
-      fetch(:branch, '')
+    def branch
+      @branch ||= fetch(:branch, '')
     end
 
     def slack_app_and_branch
-      if branch_or_not.nil?
+      if branch.nil?
         slack_app_name
       else
-        [slack_app_name, branch_or_not].join('/')
+        [slack_app_name, branch].join('/')
       end
     end
 

--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -96,11 +96,15 @@ module Capistrano
     end
 
     def rev
-      @rev ||= `git ls-remote #{repository} #{branch}`.split(" ").first
+      @rev ||= `git ls-remote #{repository} #{branch_or_not}`.split(" ").first
+    end
+
+    def branch_or_not
+      fetch(:branch, '')
     end
 
     def deploy_target
-      [slack_app_name, branch].join('/') + (rev ? " (#{rev[0..5]})" : "")
+      [slack_app_name, branch_or_not].join('/') + (rev ? " (#{rev[0..5]})" : "")
     end
 
     def self.extended(configuration)


### PR DESCRIPTION
In the project I'm working on, we do not always have branch defined. Without a branch defined, unfortunately, an exception is thrown. An empty string seems like a reasonable value to return if there is no branch defined.